### PR TITLE
Allow specification of a default branch

### DIFF
--- a/.env_calcite
+++ b/.env_calcite
@@ -1,5 +1,6 @@
 PACKAGE_NAME=calcite
 SVN_NAME=calcite
 GIT_NAME=calcite
+GIT_DEFAULT_BRANCH=main
 EXTRA_SVN_DIRS=
 NEXUS_GROUP=org.apache.calcite

--- a/.env_calcite-avatica
+++ b/.env_calcite-avatica
@@ -1,5 +1,6 @@
 PACKAGE_NAME=calcite
 SVN_NAME=calcite
 GIT_NAME=calcite-avatica
+GIT_DEFAULT_BRANCH=main
 EXTRA_SVN_DIRS=
 NEXUS_GROUP=org.apache.calcite

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Apache License 2.0
 Changelog
 ---------
 
+2020-07-29
+* Allow specification of default branch name with GIT_DEFAULT_BRANCH
+
 2019-12-22
 * Skip initialization of SVN server when SVN_NAME is empty
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - SVN_NAME
       - GIT_NAME
       - EXTRA_SVN_DIRS
+      - GIT_DEFAULT_BRANCH
     ports:
     - 80:80
     - 3960:3960

--- a/vcs-server/Dockerfile
+++ b/vcs-server/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache git-daemon
 ARG EXTRA_SVN_DIRS=
 ARG GIT_NAME=
 ARG SVN_NAME=
+ARG GIT_DEFAULT_BRANCH=master
 
 ADD dav_svn.conf /etc/apache2/conf.d/dav_svn.conf
 
@@ -18,7 +19,9 @@ auth-access = write' /home/svn/dist/conf/svnserve.conf &&\
 
 RUN mkdir /home/git/ &&\
     git config --global user.email 'test@example.com' &&\
-    git init /home/git/empty.git && cd /home/git/empty.git && git commit --allow-empty --message "Initial commit" && git branch gh-pages && git branch asf-site &&\
+    git init /home/git/empty.git && cd /home/git/empty.git &&\
+    ([ "x$GIT_DEFAULT_BRANCH" = "xmaster" ] || git checkout -b "$GIT_DEFAULT_BRANCH")&&\
+    git commit --allow-empty --message "Initial commit" && git branch gh-pages && git branch asf-site &&\
     cd /home/git &&\
     git clone --bare empty.git $GIT_NAME.git &&\
     git clone --bare empty.git $GIT_NAME-site.git &&\


### PR DESCRIPTION
I believe this solves the issue of the current code base assuming the default branch is named master.
Instead, you can now specify what the default branch would be with `GIT_DEFAULT_BRANCH`.
The default is still `master` since that is currently more common and what git itself assumes.