### PR TITLE
ci: add Apache Calcite release dry-run workflow

### DIFF
--- a/.github/workflows/calcite-release.yml
+++ b/.github/workflows/calcite-release.yml
@@ -1,0 +1,111 @@
+name: Apache Calcite release dry-run
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  calcite-release:
+    name: prepareVote + publishDist (Apache Calcite)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Check out asflike-release-environment
+        uses: actions/checkout@v4
+        with:
+          path: asflike
+
+      - name: Start asflike services (Calcite layout)
+        working-directory: asflike
+        run: |
+          cp .env_calcite .env
+          # --wait blocks until every started service is `healthy` (per the
+          # healthchecks defined in docker-compose.yml). The `nexus-ready`
+          # sidecar covers the distroless Nexus stub.
+          docker compose up --build --wait
+
+      - name: Check out Apache Calcite
+        uses: actions/checkout@v4
+        with:
+          repository: apache/calcite
+          path: calcite
+          fetch-depth: 0
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Install Subversion client (svn + svnmucc)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends subversion
+          command -v svn
+          command -v svnmucc
+
+      - name: Generate throwaway GPG key for signing
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.gnupg
+          chmod 700 ~/.gnupg
+          echo 'allow-loopback-pinentry' > ~/.gnupg/gpg-agent.conf
+          echo 'pinentry-mode loopback' > ~/.gnupg/gpg.conf
+          chmod 600 ~/.gnupg/gpg-agent.conf ~/.gnupg/gpg.conf
+          gpgconf --kill gpg-agent || true
+          cat > /tmp/gpg-batch <<'EOF'
+          %no-protection
+          Key-Type: RSA
+          Key-Length: 3072
+          Name-Real: ASFLike Release Test
+          Name-Email: test@example.com
+          Expire-Date: 0
+          %commit
+          EOF
+          gpg --batch --gen-key /tmp/gpg-batch
+          rm /tmp/gpg-batch
+          KEY_ID=$(gpg --list-secret-keys --keyid-format=long --with-colons \
+                    | awk -F: '/^sec:/ {print $5; exit}')
+          echo "GPG_KEY_ID=$KEY_ID" >> "$GITHUB_ENV"
+
+      - name: Configure ~/.gradle/gradle.properties
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.gradle
+          cat >> ~/.gradle/gradle.properties <<EOF
+          signing.gnupg.keyName=${GPG_KEY_ID}
+          asfCommitterId=test
+          asfTestNexusUsername=test
+          asfTestNexusPassword=test
+          asfTestSvnUsername=test
+          asfTestSvnPassword=test
+          asfTestGitSourceUsername=test
+          asfTestGitSourcePassword=test
+          asfTestGitSitePreviewUsername=test
+          asfTestGitSitePreviewPassword=test
+          EOF
+
+      - name: ./gradlew prepareVote -Prc=0
+        working-directory: calcite
+        run: ./gradlew --no-daemon --stacktrace -PuseGpgCmd -Prc=0 prepareVote
+
+      - name: ./gradlew publishDist -Prc=0
+        working-directory: calcite
+        run: ./gradlew --no-daemon --stacktrace -PuseGpgCmd -Prc=0 publishDist
+
+      - name: Dump asflike service logs on failure
+        if: failure()
+        working-directory: asflike
+        run: docker compose logs --no-color
+
+      - name: Stop asflike services
+        if: always()
+        working-directory: asflike
+        run: docker compose down --volumes --remove-orphans

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,12 @@ services:
     ports:
       - 80:80
       - 3960:3960
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1/svn/dist/"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 2s
   git:
     container_name: git-server
     env_file:
@@ -21,6 +27,12 @@ services:
         - GIT_NAME
     ports:
       - 9418:9418
+    healthcheck:
+      test: ["CMD-SHELL", "git ls-remote git://127.0.0.1/empty.git"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 2s
   nexus:
     container_name: nexus-stub
     env_file:
@@ -30,6 +42,21 @@ services:
       GROUP_IDS: $NEXUS_GROUP
     ports:
       - 8080:8080
+  nexus-ready:
+    # vlsi/nexus-stub uses a distroless base (no shell/curl/wget),
+    # so we expose its readiness via this sidecar's healthcheck.
+    container_name: nexus-stub-ready
+    image: curlimages/curl:8.10.1
+    depends_on:
+      nexus:
+        condition: service_started
+    command: ["sleep", "infinity"]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS -o /dev/null http://nexus:8080/service/local/staging/profiles"]
+      interval: 2s
+      timeout: 5s
+      retries: 60
+      start_period: 2s
   sonar:
     profiles:
       - sonar


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/calcite-release.yml` that boots the asflike Calcite stack (SVN over HTTP via Apache + `mod_dav_svn`, git-daemon, Nexus stub), checks out `apache/calcite`, sets up Java 17, generates a throwaway GPG key, and runs `./gradlew prepareVote -Prc=0` followed by `./gradlew publishDist -Prc=0`.
- Guards the invariant described in `CLAUDE.md`: the SVN container must keep serving HTTP DAV so `prepareVote` / `svnmucc` keep working.
- Triggers on push to `master`, on PRs targeting `master`, and via `workflow_dispatch`.

## Test plan
- [ ] CI: workflow appears in the Actions tab and runs against this PR.
- [ ] `prepareVote -Prc=0` step succeeds (stages to `dev/calcite/apache-calcite-<ver>-rc0/`, pushes RC tag to `git://127.0.0.1/calcite.git`, closes Nexus staging).
- [ ] `publishDist -Prc=0` step succeeds (promotes from `dev/...` to `release/calcite/...`, pushes release tag).
- [ ] If anything regresses (e.g. SVN over HTTP breaks again), the workflow fails — confirming it catches the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)